### PR TITLE
Replace broken custom Deserialize impl with derive

### DIFF
--- a/src/websocket/types/room/room_object_macros.rs
+++ b/src/websocket/types/room/room_object_macros.rs
@@ -49,53 +49,12 @@ pub(crate) mod vec_update {
     use super::Updatable;
 
     /// Update structure for a Vec.
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, serde_derive::Deserialize)]
+    #[serde(untagged)]
     pub(crate) enum VecUpdate<T> {
         Array(Vec<T>),
         PartialObj(VecPartialUpdate<T>),
     }
-    #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-    const _IMPL_DESERIALIZE_FOR_VecUpdate: () = {
-        extern crate serde as _serde;
-        impl<'de, T> _serde::Deserialize<'de> for VecUpdate<T>
-        where
-            T: _serde::Deserialize<'de>,
-        {
-            fn deserialize<__D>(__deserializer: __D) -> _serde::export::Result<Self, __D::Error>
-            where
-                __D: _serde::Deserializer<'de>,
-            {
-                let err1;
-                let err2;
-                let __content =
-                    <_serde::private::de::Content as Deserialize>::deserialize(__deserializer)?;
-                match Result::map(
-                    Vec::<T>::deserialize(
-                        _serde::private::de::ContentRefDeserializer::<__D::Error>::new(&__content),
-                    ),
-                    VecUpdate::Array,
-                ) {
-                    Ok(value) => return Ok(value),
-                    Err(e) => err1 = e,
-                }
-                match Result::map(
-                    VecPartialUpdate::<T>::deserialize(
-                        _serde::private::de::ContentRefDeserializer::<__D::Error>::new(&__content),
-                    ),
-                    VecUpdate::PartialObj,
-                ) {
-                    Ok(value) => return Ok(value),
-                    Err(e) => err2 = e,
-                }
-                _serde::export::Err(_serde::de::Error::custom(format!(
-                    "data did not match any variant of \
-                     untagged enum VecUpdate (error for \
-                     Array: {}, error for PartialObj: {})",
-                    err1, err2
-                )))
-            }
-        }
-    };
 
     #[derive(Debug, Clone)]
     pub struct VecPartialUpdate<T>(Vec<(u32, T)>);


### PR DESCRIPTION
I'm really not sure what compelled me to originally write this in 6fd385abf83a9de00e51d939e7a07283d1cfe4aa. I'm 100% sure this is a copy of the derived code with `#[serde(untagged)]`, and I think when I do this sort of thing I'd usually edit something after copying it. But I can't find anything changed, and the derive seems to work fine now?

In any case, the handwritten code broke with the latest serde update because it referred to private inner parts, and that's not great.

Thanks to @duckymirror @ https://github.com/daboross/rust-screeps-api/pull/6#issuecomment-758538434 for finding this!