### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,24 +37,24 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_ignored = "0.0.4"
-serde-tuple-vec-map = "0.2"
+serde_ignored = "0.1"
+serde-tuple-vec-map = "1.0"
 arrayvec = "0.5"
 time = "0.1"
 # HTTP
 futures = "0.3"
 url = "2.0"
-hyper = "0.13"
-bytes = "0.5"
+hyper = { version = "0.14", features = ["client", "http1", "stream"] }
+bytes = "1.0"
 # Sync HTTP wrapper
-tokio = { version = "0.2", optional = true }
-hyper-tls = { version = "0.4", optional = true }
+tokio = { version = "1.0", optional = true }
+hyper-tls = { version = "0.5", optional = true }
 # Websockets
-rand = "0.7"
+rand = "0.8"
 num = { version = "0.3", default-features = false }
 
 [features]
-sync = ["tokio", "hyper-tls"]
+sync = ["tokio", "hyper-tls", "tokio/rt-multi-thread"]
 protocol-docs = []
 default = ["sync"]
 # enables tests which modify game state (temporarily, but still)
@@ -71,7 +71,7 @@ clap = "2"
 # socket connections in ws-debug example
 futures01 = { package = "futures", version = "0.1" }
 tokio01 = { package = "tokio", version = "0.1" }
-websocket = "0.23"
+websocket = "0.26"
 # pretty printing in ws-debug.
 serde_json = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ appveyor = { service = "github", repository = "daboross/rust-screeps-api", branc
 # Logging
 log = "0.4"
 # Parsing
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_ignored = "0.1"
 serde-tuple-vec-map = "1.0"

--- a/src/data/errors.rs
+++ b/src/data/errors.rs
@@ -2,7 +2,7 @@
 use crate::error;
 
 /// JSON API error result from the server.
-#[derive(serde_derive::Deserialize, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct ApiError {
     /// The error string.
     pub error: String,

--- a/src/data/room_name.rs
+++ b/src/data/room_name.rs
@@ -2,6 +2,8 @@
 use std::borrow::Cow;
 use std::{error, fmt, ops};
 
+use serde::{Deserialize, Serialize};
+
 /// A structure representing a room name.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct RoomName {
@@ -249,7 +251,7 @@ impl<'a> fmt::Display for RoomNameParseError<'a> {
     }
 }
 
-mod serde {
+mod _serde {
     use super::{parse_or_cheap_failure, RoomName};
 
     use std::fmt;

--- a/src/data/rooms.rs
+++ b/src/data/rooms.rs
@@ -1,4 +1,6 @@
 //! Room result structures.
+use serde::{Deserialize, Serialize};
+
 use crate::{decoders::timespec_seconds, error};
 
 /// A room state, returned by room status.

--- a/src/data/users.rs
+++ b/src/data/users.rs
@@ -1,4 +1,5 @@
 //! User-related shared data structures.
+use serde::{Deserialize, Serialize};
 
 /// Badge type - what shape a badge should be.
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug)]

--- a/src/endpoints/leaderboard/find_rank.rs
+++ b/src/endpoints/leaderboard/find_rank.rs
@@ -1,11 +1,12 @@
 //! Interpreting the result of finding the rank of a specific user.
+use serde::{Deserialize, Serialize};
 
 use crate::data;
 use crate::error::{ApiError, Result};
 use crate::EndpointResult;
 
 /// Raw result for when the API endpoint is called with a specific season id.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct SingleResponse {
     // I have no idea what this is for, so not including in the documented and expected response.
@@ -18,14 +19,14 @@ pub(crate) struct SingleResponse {
 }
 
 /// Raw result for when the API endpoint is called without a specific season id.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct AllSeasonRanksResponse {
     ok: i32,
     list: Vec<InnerAllSeasonsResponse>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 struct InnerAllSeasonsResponse {
     // Again, no idea what this is for, so I'm not including it in the documented response.
     // _id: String,

--- a/src/endpoints/leaderboard/page.rs
+++ b/src/endpoints/leaderboard/page.rs
@@ -1,13 +1,15 @@
 //! Interpreting user leaderboard page results.
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use super::find_rank;
 use crate::data;
 use crate::error::{ApiError, Result};
 use crate::EndpointResult;
 
 /// Raw list results.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[doc(hidden)]
 pub(crate) struct Response {
     ok: i32,
@@ -16,7 +18,7 @@ pub(crate) struct Response {
     users: HashMap<String, ExtendedUserInfo>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 struct ResponseRankedUser {
     //_id: String, // exists, but I don't know what it's for.
     rank: u32,
@@ -25,7 +27,7 @@ struct ResponseRankedUser {
     user: String,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 struct ExtendedUserInfo {
     _id: String,
     username: String,

--- a/src/endpoints/leaderboard/season_list.rs
+++ b/src/endpoints/leaderboard/season_list.rs
@@ -1,18 +1,19 @@
 //! Interpreting leaderboard season list results.
+use serde::{Deserialize, Serialize};
 
 use crate::data;
 use crate::error::{ApiError, Result};
 use crate::EndpointResult;
 
 /// Call raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct Response {
     ok: i32,
     seasons: Vec<Season>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 struct Season {
     _id: String,
     name: String,

--- a/src/endpoints/login.rs
+++ b/src/endpoints/login.rs
@@ -1,6 +1,8 @@
 //! Interpreting login responses.
 use std::borrow::Cow;
 
+use serde::{Deserialize, Serialize};
+
 use crate::data;
 use crate::error::{ApiError, Result};
 
@@ -30,7 +32,7 @@ impl<'a> LoginArgs<'a> {
 }
 
 /// Login raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 pub(crate) struct Response {
     ok: i32,
     token: Option<String>,

--- a/src/endpoints/map_stats.rs
+++ b/src/endpoints/map_stats.rs
@@ -3,7 +3,7 @@
 //! Note: currently only supports "owner0" stats, not any other statistic that can also be retrieved with the same API.
 use std::convert::AsRef;
 
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::data::{self, RoomName};
 use crate::decoders::optional_timespec_seconds;
@@ -88,7 +88,7 @@ where
 }
 
 /// Map stats raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct Response {
     ok: i32,
@@ -98,7 +98,7 @@ pub(crate) struct Response {
     users: Vec<(String, UserResponse)>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 #[serde(rename_all = "camelCase")]
 struct RoomResponse {
     status: String,
@@ -115,7 +115,7 @@ struct RoomResponse {
     hard_sign: Option<data::HardSign>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 struct UserResponse {
     badge: data::Badge,
     _id: String,

--- a/src/endpoints/memory_segment.rs
+++ b/src/endpoints/memory_segment.rs
@@ -1,4 +1,6 @@
 //! Interpreting memory calls.
+use serde::Deserialize;
+
 use crate::{
     data,
     error::{ApiError, Result},
@@ -6,7 +8,7 @@ use crate::{
 };
 
 /// Call raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct Response {
     ok: i32,

--- a/src/endpoints/my_info.rs
+++ b/src/endpoints/my_info.rs
@@ -1,6 +1,7 @@
 //! Interpreting user self information.
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
 use time::Timespec;
 
 use crate::{
@@ -11,7 +12,7 @@ use crate::{
 };
 
 /// User info raw result.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Response {
     ok: i32,

--- a/src/endpoints/recent_pvp.rs
+++ b/src/endpoints/recent_pvp.rs
@@ -1,4 +1,5 @@
 //! Interpreting rooms in which PvP recently occurred. This is an "experimental" endpoint.
+use serde::Deserialize;
 
 use crate::{
     data,
@@ -33,20 +34,20 @@ impl RecentPvpArgs {
 }
 
 /// Recent PvP raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 pub(crate) struct Response {
     ok: i32,
     #[serde(with = "::tuple_vec_map")]
     pvp: Vec<(String, InnerShard)>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 struct InnerShard {
     rooms: Vec<InnerRoom>,
     time: u32,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 struct InnerRoom {
     _id: String,
     #[serde(rename = "lastPvpTime")]

--- a/src/endpoints/register.rs
+++ b/src/endpoints/register.rs
@@ -1,6 +1,8 @@
 //! Creating registration calls and interpreting registration results.
 use std::borrow::Cow;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     data,
     error::{ApiError, Result},
@@ -47,7 +49,7 @@ impl<'a> RegistrationArgs<'a> {
 }
 
 /// Raw registration response.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 pub(crate) struct Response {
     ok: i32,
 }

--- a/src/endpoints/room_overview.rs
+++ b/src/endpoints/room_overview.rs
@@ -1,4 +1,5 @@
 //! Interpreting room overview results.
+use serde::{Deserialize, Serialize};
 
 use crate::{
     data::{self, Badge},
@@ -7,7 +8,7 @@ use crate::{
 };
 
 /// Room overview raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Response {
     ok: i32,
@@ -16,13 +17,13 @@ pub(crate) struct Response {
     stats_max: Option<RoomTotalStatsResponse>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 struct OwnerResponse {
     username: String,
     badge: Badge,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 #[serde(rename_all = "camelCase")]
 struct RoomStatsResponse {
     energy_harvested: Vec<StatPointResponse>,
@@ -33,14 +34,14 @@ struct RoomStatsResponse {
     creeps_lost: Vec<StatPointResponse>,
 }
 
-#[derive(serde_derive::Deserialize, Copy, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Copy, Clone, Hash, Debug)]
 #[serde(rename_all = "camelCase")]
 struct StatPointResponse {
     value: u32,
     end_time: u32,
 }
 
-#[derive(serde_derive::Deserialize, Copy, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Copy, Clone, Hash, Debug)]
 #[serde(rename_all = "camelCase")]
 struct RoomTotalStatsResponse {
     energy_8: u32,

--- a/src/endpoints/room_status.rs
+++ b/src/endpoints/room_status.rs
@@ -1,4 +1,5 @@
 //! Interpreting room status results.
+use serde::{Deserialize, Serialize};
 
 use crate::{
     data::{self, RoomName, RoomState},
@@ -8,13 +9,13 @@ use crate::{
 };
 
 /// Room overview raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 pub(crate) struct Response {
     ok: i32,
     room: Option<InnerRoom>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 struct InnerRoom {
     /// The room's name
     _id: String,

--- a/src/endpoints/room_terrain.rs
+++ b/src/endpoints/room_terrain.rs
@@ -1,6 +1,6 @@
 //! Interpreting room terrain results.
-
 use arrayvec::ArrayVec;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     data,
@@ -9,13 +9,13 @@ use crate::{
 };
 
 /// Room overview raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 pub(crate) struct Response {
     ok: i32,
     terrain: Option<Vec<InnerResponse>>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 struct InnerResponse {
     // this is returned as part of the data, but what the heck is it even for?
     /// A cache key maybe?

--- a/src/endpoints/set_memory_segment.rs
+++ b/src/endpoints/set_memory_segment.rs
@@ -1,6 +1,8 @@
 //! Interpreting memory calls.
 use std::borrow::Cow;
 
+use serde::Serialize;
+
 use crate::{
     data,
     error::{ApiError, Result},
@@ -8,7 +10,7 @@ use crate::{
 };
 
 /// Call raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct Response {
     ok: i32,

--- a/src/endpoints/shards.rs
+++ b/src/endpoints/shards.rs
@@ -1,4 +1,5 @@
 //! Interpreting shard info calls.
+use serde::Deserialize;
 
 use crate::{
     data,
@@ -7,13 +8,13 @@ use crate::{
 };
 
 /// Shard info raw result.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 pub(crate) struct Response {
     ok: i32,
     shards: Vec<ShardResponse>,
 }
 
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 struct ShardResponse {
     users: u32,
     name: String,

--- a/src/endpoints/template.rs
+++ b/src/endpoints/template.rs
@@ -1,4 +1,6 @@
 //! Interpreting generic template calls.
+use serde::Deserialize;
+
 use crate::{
     data,
     error::{ApiError, Result},
@@ -6,7 +8,7 @@ use crate::{
 };
 
 /// Call raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 #[doc(hidden)]
 pub(crate) struct Response {
     ok: i32,

--- a/src/endpoints/world_start_room.rs
+++ b/src/endpoints/world_start_room.rs
@@ -1,4 +1,5 @@
 //! Interpreting generic template calls.
+use serde::Deserialize;
 
 use crate::{
     data,
@@ -7,7 +8,7 @@ use crate::{
 };
 
 /// World start room raw result.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(Deserialize, Clone, Hash, Debug)]
 pub(crate) struct Response {
     ok: i32,
     room: Vec<String>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum ErrorKind {
     /// URL parsing error.
     Url(url::ParseError),
     /// Error connecting to the server, or error parsing a URL provided.
-    Hyper(hyper::error::Error),
+    Hyper(hyper::Error),
     /// IO error.
     Io(io::Error),
     /// Error for when the server responds with a non-success HTTP status code.
@@ -164,8 +164,8 @@ impl From<serde_json::error::Error> for Error {
     }
 }
 
-impl From<hyper::error::Error> for Error {
-    fn from(err: hyper::error::Error) -> Error {
+impl From<hyper::Error> for Error {
+    fn from(err: hyper::Error) -> Error {
         ErrorKind::Hyper(err).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,6 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]
-extern crate serde_derive;
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub struct Api<C> {
     /// The authentication token.
     auth_token: TokenStorage,
     /// The hyper client.
-    client: hyper::Client<C>,
+    client: hyper::client::Client<C>,
 }
 
 impl<C> Clone for Api<C>
@@ -173,7 +173,7 @@ impl<C> Api<C> {
     /// The returned instance can be used to make anonymous calls. Use [`Api::with_token`] or
     /// [`Api::set_token`] to enable authenticated access.
     #[inline]
-    pub fn new(client: hyper::Client<C>) -> Self {
+    pub fn new(client: hyper::client::Client<C>) -> Self {
         Api {
             url: default_url(),
             client: client,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use hyper::client::HttpConnector;
-use hyper::{self, Client};
+use hyper::{self, client::Client};
 use hyper_tls::HttpsConnector;
 
 use crate::{

--- a/src/websocket/connecting.rs
+++ b/src/websocket/connecting.rs
@@ -125,7 +125,7 @@ pub fn transform_url<U: AsRef<str> + ?Sized>(url: &U) -> Result<Url, UrlError> {
     impl fmt::Display for GenServerAndSessionId {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let mut rng = rand::thread_rng();
-            write!(f, "../socket/{:04}/", rng.gen_range(0, 1000))?;
+            write!(f, "../socket/{:04}/", rng.gen_range(0..1000))?;
 
             for _ in 0..8 {
                 write!(f, "{}", *VALID_CHARS.choose(&mut rng).unwrap() as char)?;

--- a/src/websocket/types/messages.rs
+++ b/src/websocket/types/messages.rs
@@ -1,7 +1,7 @@
 //! Update parsing for user messages and conversation updates.
 
 /// Specification on whether a message is incoming or outgoing.
-#[derive(serde_derive::Deserialize, Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(serde::Deserialize, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum MessageDirectionType {
     /// Incoming messages: messages sent by someone other than the subscribed user.
     #[serde(rename = "in")]
@@ -12,7 +12,7 @@ pub enum MessageDirectionType {
 }
 
 /// Content of a newly sent or received message update.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 pub struct Message {
     /// The unique identifier for this message.
     #[serde(rename = "_id")]
@@ -47,7 +47,7 @@ pub struct Message {
 }
 
 /// Update for a newly received message.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 pub struct MessageUpdate {
     /// The message.
     pub message: Message,
@@ -57,7 +57,7 @@ pub struct MessageUpdate {
 }
 
 /// Update on whether a message is unread or not.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 pub struct MessageUnreadUpdate {
     /// The unique identifier for this message.
     #[serde(rename = "_id")]
@@ -73,7 +73,7 @@ pub struct MessageUnreadUpdate {
 /// Update on a conversation between two specific users. This is either a new message sent by one of the users
 /// (either the subscribed one or the other one), or an update indicating that a message previously sent has now
 /// been read.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ConversationUpdate {
     /// A new message has been sent.

--- a/src/websocket/types/room/mod.rs
+++ b/src/websocket/types/room/mod.rs
@@ -17,7 +17,7 @@ pub mod objects;
 use self::flags::{deserialize_flags, Flag};
 
 /// Update for detailed room information.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RoomUpdate {
     /// The game time when this update was created.
@@ -58,7 +58,7 @@ pub struct RoomUpdate {
 /// "info" struct to go with room update.
 ///
 /// TODO: find all variants and parse into enum.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 pub struct RoomUpdateInfo {
     /// Usually "world" for regular rooms.
     pub mode: Option<String>,
@@ -69,7 +69,7 @@ pub struct RoomUpdateInfo {
 
 with_update_struct! {
     /// Information on a user which is packaged with a room update.
-    #[derive(serde_derive::Deserialize, Clone, Hash, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Hash, Debug, PartialEq)]
     pub struct RoomUserInfo {
         /// User ID
         #[serde(rename = "_id")]
@@ -84,6 +84,6 @@ with_update_struct! {
     }
 
     /// The update structure for RoomUpdateUserInfo
-    #[derive(serde_derive::Deserialize, Clone, Hash, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Hash, Debug, PartialEq)]
     pub struct RoomUserInfoUpdate { ... }
 }

--- a/src/websocket/types/room/objects/construction_site.rs
+++ b/src/websocket/types/room/objects/construction_site.rs
@@ -4,7 +4,7 @@ use crate::data::RoomName;
 /// Type of structure (not general room object).
 ///
 /// Currently only used when decoding ConstructionSites.
-#[derive(Clone, Debug, PartialEq, Eq, serde_derive::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum StructureType {
     /// StructureSpawn structure type

--- a/src/websocket/types/room/objects/controller.rs
+++ b/src/websocket/types/room/objects/controller.rs
@@ -8,7 +8,7 @@ implement_update_for! {
     RoomSign;
 
     /// Update for room signs
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     (no_extra_meta)
     pub struct RoomSignUpdate {
         /// The game time when the sign was set.
@@ -27,7 +27,7 @@ implement_update_for! {
 
 with_update_struct! {
     /// A struct describing a room's reservation.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct ControllerReservation {
         /// The user ID of the user reserving this controller.
@@ -37,7 +37,7 @@ with_update_struct! {
     }
 
     /// The update structure for a controller reservation.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct ControllerReservationUpdate { ... }
 }

--- a/src/websocket/types/room/objects/creep.rs
+++ b/src/websocket/types/room/objects/creep.rs
@@ -8,7 +8,7 @@ with_update_struct! {
     /// A struct describing a creep part.
     ///
     /// TODO: parse creep part boosts.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct CreepPart {
         /// Part health, out of 100.
@@ -21,12 +21,14 @@ with_update_struct! {
     }
 
     /// The update structure for a `CreepPart`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct CreepPartUpdate { ... }
 }
 
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    serde::Serialize, serde::Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 /// A type of creep part.
 pub enum CreepPartType {
@@ -53,7 +55,7 @@ basic_updatable!(CreepPartType);
 
 with_update_struct! {
     /// A struct describing a creep's message conveyed with `say`.
-    #[derive(serde_derive::Deserialize, Default, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Default, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct CreepMessage {
         /// If true, the message is visible to all players.
@@ -63,14 +65,14 @@ with_update_struct! {
     }
 
     /// The update structure for a `CreepMessage`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct CreepMessageUpdate { ... }
 }
 
 with_update_struct! {
     /// A struct describing a creep's actions.
-    #[derive(serde_derive::Deserialize, Default, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Default, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct CreepActions {
         /// The location this creep harvested last tick.
@@ -102,7 +104,7 @@ with_update_struct! {
     }
 
     /// The update structure for a `CreepActions`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct CreepActionsUpdate { ... }
 }

--- a/src/websocket/types/room/objects/lab.rs
+++ b/src/websocket/types/room/objects/lab.rs
@@ -51,7 +51,7 @@ with_structure_fields_and_update_struct! {
 
 with_update_struct! {
     /// A struct describing the source labs for a lab performing a mineral reaction.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     pub struct LabActionTarget {
         /// The x position of the first source lab.
         pub x1: u32,
@@ -64,13 +64,13 @@ with_update_struct! {
     }
 
     /// The update structure for a `LabActionTarget`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     pub struct LabActionTargetUpdate { ... }
 }
 
 with_update_struct! {
     /// A struct describing a lab's actions.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct StructureLabActions {
         /// The two source labs that provided minerals for the reaction that was run last tick.
@@ -78,7 +78,7 @@ with_update_struct! {
     }
 
     /// The update structure for a `StructureLabActions`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct StructureLabActionsUpdate { ... }
 }

--- a/src/websocket/types/room/objects/link.rs
+++ b/src/websocket/types/room/objects/link.rs
@@ -42,7 +42,7 @@ with_structure_fields_and_update_struct! {
 
 with_update_struct! {
     /// A struct describing a link's actions.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct StructureLinkActions {
         /// The x,y position the link last transfered energy to.
@@ -50,7 +50,7 @@ with_update_struct! {
     }
 
     /// The update structure for StructureLinkActions.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct StructureLinkActionsUpdate { ... }
 }

--- a/src/websocket/types/room/objects/mod.rs
+++ b/src/websocket/types/room/objects/mod.rs
@@ -42,7 +42,7 @@ pub use self::{
 };
 
 /// Enum describing all known room objects.
-#[derive(serde_derive::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum KnownRoomObject {
     /// Source object.

--- a/src/websocket/types/room/objects/portal.rs
+++ b/src/websocket/types/room/objects/portal.rs
@@ -6,7 +6,7 @@ use crate::{
 
 with_update_struct! {
     /// The destination for a portal structure.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     pub struct PortalDestination {
         /// The room name the other side of this portal ends at.
         pub room: RoomName,
@@ -17,7 +17,7 @@ with_update_struct! {
     }
 
     /// The update structure for a portal destination.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     pub struct PortalDestinationUpdate { ... }
 }
 

--- a/src/websocket/types/room/objects/shared.rs
+++ b/src/websocket/types/room/objects/shared.rs
@@ -2,7 +2,7 @@
 
 with_update_struct! {
     /// A struct describing the destination of various actions within action logs.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     pub struct ActionLogTarget {
         /// The in-room x position of this target.
         pub x: u32,
@@ -11,6 +11,6 @@ with_update_struct! {
     }
 
     /// The update structure for an `ActionLogTarget`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     pub struct ActionLogTargetUpdate { ... }
 }

--- a/src/websocket/types/room/objects/spawn.rs
+++ b/src/websocket/types/room/objects/spawn.rs
@@ -3,7 +3,7 @@ use crate::data::RoomName;
 
 with_update_struct! {
     /// A struct describing a creep currently spawning (used as part of the update for a StructureSpawn).
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct SpawningCreep {
         /// The name of this creep, unique per player.
@@ -16,7 +16,7 @@ with_update_struct! {
     }
 
     /// The update structure for a spawning creep.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct SpawningCreepUpdate { ... }
 }

--- a/src/websocket/types/room/objects/tombstone.rs
+++ b/src/websocket/types/room/objects/tombstone.rs
@@ -48,7 +48,7 @@ impl Tombstone {
 mod test {
     use serde::Deserialize;
 
-    use super::{Tombstone};
+    use super::Tombstone;
 
     #[test]
     fn parse_simple_tombstone() {

--- a/src/websocket/types/room/objects/tower.rs
+++ b/src/websocket/types/room/objects/tower.rs
@@ -40,7 +40,7 @@ with_structure_fields_and_update_struct! {
 
 with_update_struct! {
     /// A struct describing a tower's actions.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct StructureTowerActions {
         /// Where this tower attacked last tick.
@@ -52,7 +52,7 @@ with_update_struct! {
     }
 
     /// The update structure for a `StructureTowerActions`.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct StructureTowerActionsUpdate { ... }
 }

--- a/src/websocket/types/room/objects/wall.rs
+++ b/src/websocket/types/room/objects/wall.rs
@@ -6,7 +6,7 @@ use crate::{
 
 with_update_struct! {
     /// Describes the decay of a decaying wall.
-    #[derive(serde_derive::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct WallDecayTime {
         /// Unix timestamp of when this wall will decay.
@@ -15,7 +15,7 @@ with_update_struct! {
     }
 
     /// The update structure for a wall decay description.
-    #[derive(serde_derive::Deserialize, Clone, Debug)]
+    #[derive(serde::Deserialize, Clone, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct WallDecayTimeUpdate {
         #[serde(with = "optional_timespec_seconds")]

--- a/src/websocket/types/room/resources.rs
+++ b/src/websocket/types/room/resources.rs
@@ -1,7 +1,10 @@
 //! Managing and parsing resource
 use std::{cmp, collections::HashMap, fmt};
 
-use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+use serde::{
+    de::{Deserializer, MapAccess, Visitor},
+    Deserialize, Serialize,
+};
 
 use crate::websocket::room_object_macros::Updatable;
 

--- a/src/websocket/types/room/room_object_macros.rs
+++ b/src/websocket/types/room/room_object_macros.rs
@@ -49,7 +49,7 @@ pub(crate) mod vec_update {
     use super::Updatable;
 
     /// Update structure for a Vec.
-    #[derive(Debug, Clone, serde_derive::Deserialize)]
+    #[derive(Debug, Clone, serde::Deserialize)]
     #[serde(untagged)]
     pub(crate) enum VecUpdate<T> {
         Array(Vec<T>),
@@ -538,7 +538,7 @@ macro_rules! with_update_struct {
 }
 
 /// This macro creates the struct described within the invocation, but with an additional 4 fields common to all
-/// room objects, and with `#[derive(serde_derive::Deserialize)]`. The structure definition is then passed on to `with_update_struct`.
+/// room objects, and with `#[derive(serde::Deserialize)]`. The structure definition is then passed on to `with_update_struct`.
 macro_rules! with_base_fields_and_update_struct {
     (
         $( #[$struct_attr:meta] )*
@@ -592,7 +592,7 @@ macro_rules! with_base_fields_and_update_struct {
     ) => (
         with_update_struct! {
             $( #[$struct_attr] )*
-            #[derive(serde_derive::Deserialize)]
+            #[derive(serde::Deserialize)]
             pub struct $name {
                 /// Unique 'id' identifier for all game objects on a server.
                 #[serde(rename = "_id")]
@@ -613,7 +613,7 @@ macro_rules! with_base_fields_and_update_struct {
             }
 
             $( #[$update_struct_attr] )*
-            #[derive(serde_derive::Deserialize)]
+            #[derive(serde::Deserialize)]
             $( ($update_extra) )*
             pub struct $update_name {
                 #[serde(rename = "_id")]

--- a/src/websocket/types/user_console.rs
+++ b/src/websocket/types/user_console.rs
@@ -37,13 +37,13 @@ impl UserConsoleUpdate {
 // Separate representation for deserializing needed in order to have 'Error' variant be a
 // struct-like variant rather than a tuple-like variant.
 
-#[derive(serde_derive::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug)]
 struct InnerUpdateInnerMessages {
     log: Vec<String>,
     results: Vec<String>,
 }
 
-#[derive(serde_derive::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug)]
 struct InnerUpdateRepresentation {
     error: Option<String>,
     messages: Option<InnerUpdateInnerMessages>,

--- a/src/websocket/types/user_cpu.rs
+++ b/src/websocket/types/user_cpu.rs
@@ -1,7 +1,7 @@
 //! Parsing for user CPU/memory updates.
 
 /// Notification for Update for a user's last tick CPU usage and total memory usage.
-#[derive(serde_derive::Deserialize, Clone, Hash, Debug)]
+#[derive(serde::Deserialize, Clone, Hash, Debug)]
 pub struct UserCpuUpdate {
     /// The CPU usage last tick.
     #[serde(rename = "cpu")]


### PR DESCRIPTION
This is mostly housekeeping. Updates the main codebase to use tokio 1.0, and misc. other dependencies.

This should make it nicer to interop with other libraries also updated to tokio 1.0! Besides that, won't have much affect. And you can always use compat stuff to use older versions, as demonstrated by the demos using the `websocket` crate stuck all the way back on tokio 0.1.