### PR TITLE
Fixed remaining failing tests

### DIFF
--- a/src/websocket/types/room/objects/lab.rs
+++ b/src/websocket/types/room/objects/lab.rs
@@ -18,7 +18,7 @@ with_structure_fields_and_update_struct! {
         /// The total amount of each resource that can be stored in this structure.
         pub store_capacity_resource: Store,
         /// The tick until which this lab can't run any reactions.
-        pub cooldown_time: i32,
+        pub cooldown_time: Option<i32>,
         /// A record of all actions this structure performed last tick.
         pub action_log: StructureLabActions,
         /// Whether or not an attack on this structure will send an email to the owner automatically.
@@ -34,7 +34,7 @@ with_structure_fields_and_update_struct! {
         - disabled: bool,
         - store: Store,
         - store_capacity_resource: Store,
-        - cooldown_time: i32,
+        - cooldown_time: Option<i32>,
         - action_log: StructureLabActions,
         - notify_when_attacked: bool,
     }
@@ -192,7 +192,7 @@ mod test {
                 store_capacity_resource: store! { Energy: 2000, UtriumOxide: 3000 },
                 hits: 500,
                 hits_max: 500,
-                cooldown_time: 30246725,
+                cooldown_time: Some(30246725),
                 notify_when_attacked: false,
                 disabled: false,
                 action_log: StructureLabActions {
@@ -269,7 +269,7 @@ mod test {
                 store_capacity_resource: store! { Energy: 2000, UtriumOxide: 3000 },
                 hits: 500,
                 hits_max: 500,
-                cooldown_time: 30246735,
+                cooldown_time: Some(30246735),
                 notify_when_attacked: false,
                 disabled: false,
                 action_log: StructureLabActions { run_reaction: None },
@@ -388,10 +388,58 @@ mod test {
                 hits_max: 500,
                 notify_when_attacked: true,
                 disabled: false,
-                cooldown_time: 23464205,
+                cooldown_time: Some(23464205),
                 action_log: StructureLabActions { run_reaction: None },
                 user: "5a8466038f866773f59fa6c8".to_owned(),
             }
         );
+    }
+
+    #[test]
+    fn parse_lab_null_cooldown() {
+        let json = json!({
+          "_id": "583f5dba29a7bf89761d7511",
+          "actionLog": {
+            "reverseReaction": null,
+            "runReaction": null
+          },
+          "cooldown": 0,
+          "hits": 500,
+          "hitsMax": 500,
+          "notifyWhenAttacked": true,
+          "room": "W31N48",
+          "store": {
+            "energy": 2000
+          },
+          "storeCapacity": 5000,
+          "storeCapacityResource": {
+            "energy": 2000
+          },
+          "type": "lab",
+          "user": "57cd3be0559868c84d297d87",
+          "x": 28,
+          "y": 31
+        });
+
+        let obj = StructureLab::deserialize(json).unwrap();
+
+        assert_eq!(
+            obj,
+            StructureLab {
+                room: RoomName::new("W31N48").unwrap(),
+                x: 28,
+                y: 31,
+                id: "583f5dba29a7bf89761d7511".to_owned(),
+                store: store! { Energy: 2000 },
+                store_capacity_resource: store! { Energy: 2000 },
+                hits: 500,
+                hits_max: 500,
+                notify_when_attacked: true,
+                disabled: false,
+                cooldown_time: None,
+                action_log: StructureLabActions { run_reaction: None },
+                user: "57cd3be0559868c84d297d87".to_owned()
+            }
+        )
     }
 }

--- a/src/websocket/types/room/objects/terminal.rs
+++ b/src/websocket/types/room/objects/terminal.rs
@@ -29,7 +29,8 @@ with_base_fields_and_update_struct! {
         #[serde(default)]
         pub cooldown_time: u32,
         /// Whether or not an attack on this structure will send an email to the owner automatically.
-        pub notify_when_attacked: Option<bool>,
+        #[serde(default)]
+        pub notify_when_attacked: bool,
         /// The resources and amounts of each resource some game object holds.
         pub store: Store,
     }
@@ -46,7 +47,7 @@ with_base_fields_and_update_struct! {
         #[serde(rename = "energyCapacity")]
         - capacity: i32,
         - cooldown_time: u32,
-        - notify_when_attacked: Option<bool>,
+        - notify_when_attacked: bool,
         - store: Store,
     }
 }
@@ -93,7 +94,7 @@ mod test {
                 capacity: 300000,
                 hits: 3000,
                 hits_max: 3000,
-                notify_when_attacked: Some(true),
+                notify_when_attacked: true,
                 cooldown_time: 38432852,
                 disabled: false,
                 x: 4,
@@ -163,5 +164,6 @@ mod test {
         });
         let obj = StructureTerminal::deserialize(json).unwrap();
         assert_eq!(obj.store, store!());
+        assert_eq!(obj.notify_when_attacked, false);
     }
 }

--- a/src/websocket/types/room/objects/terminal.rs
+++ b/src/websocket/types/room/objects/terminal.rs
@@ -18,7 +18,7 @@ with_base_fields_and_update_struct! {
         #[serde(default)]
         pub hits_max: i32,
         /// The user ID of the owner of this structure.
-        pub user: String,
+        pub user: Option<String>,
         /// Whether or not this structure is non-functional due to a degraded controller.
         #[serde(default, rename = "off")]
         pub disabled: bool,
@@ -29,7 +29,7 @@ with_base_fields_and_update_struct! {
         #[serde(default)]
         pub cooldown_time: u32,
         /// Whether or not an attack on this structure will send an email to the owner automatically.
-        pub notify_when_attacked: bool,
+        pub notify_when_attacked: Option<bool>,
         /// The resources and amounts of each resource some game object holds.
         pub store: Store,
     }
@@ -40,13 +40,13 @@ with_base_fields_and_update_struct! {
     pub struct StructureTerminalUpdate {
         - hits: i32,
         - hits_max: i32,
-        - user: String,
+        - user: Option<String>,
         #[serde(rename = "off")]
         - disabled: bool,
         #[serde(rename = "energyCapacity")]
         - capacity: i32,
         - cooldown_time: u32,
-        - notify_when_attacked: bool,
+        - notify_when_attacked: Option<bool>,
         - store: Store,
     }
 }
@@ -93,7 +93,7 @@ mod test {
                 capacity: 300000,
                 hits: 3000,
                 hits_max: 3000,
-                notify_when_attacked: true,
+                notify_when_attacked: Some(true),
                 cooldown_time: 38432852,
                 disabled: false,
                 x: 4,
@@ -102,7 +102,7 @@ mod test {
                 ref id,
                 ref store,
                 ..
-            } if user == "5788389e3fd9069e6b546e2d"
+            } if *user == Some("5788389e3fd9069e6b546e2d".to_string())
                 && id == "59a5cc4f4733bb4c785ec4e7"
                 && *store == store! {Energy: 25000, Catalyst: 50189} =>
             {


### PR DESCRIPTION
This PR
- makes `StructureTerminal.user` optional
- makes `StructureTerminal.notify_when_attacked` `#[serde(default)]`
- makes `StructureLab.cooldown_time` optional
- adds a new test for labs without `cooldown_time`